### PR TITLE
Fix path warnings in `use` declarations for beta and nightly

### DIFF
--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -18,14 +18,14 @@ use std::ops::Range;
 use unic_ucd_bidi::bidi_class::abbr_names::*;
 use unic_ucd_bidi::BidiClass;
 
-use explicit;
-use format_chars;
-use implicit;
-use level;
-use prepare;
+use crate::explicit;
+use crate::format_chars;
+use crate::implicit;
+use crate::level;
+use crate::prepare;
 
-use level::{Level, LTR_LEVEL, RTL_LEVEL};
-use prepare::LevelRun;
+use crate::level::{Level, LTR_LEVEL, RTL_LEVEL};
+use crate::prepare::LevelRun;
 
 /// Bidi information about a single paragraph
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]

--- a/unic/bidi/src/lib.rs
+++ b/unic/bidi/src/lib.rs
@@ -88,19 +88,19 @@ pub use unic_ucd_bidi::UNICODE_VERSION;
 pub use unic_ucd_bidi::{bidi_class, BidiClass, BidiClassCategory};
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod format_chars;
 
 pub mod level;
-pub use level::Level;
+pub use crate::level::Level;
 
 mod bidi_info;
-pub use bidi_info::{BidiInfo, ParagraphInfo};
+pub use crate::bidi_info::{BidiInfo, ParagraphInfo};
 
 mod explicit;
 
 mod implicit;
 
 mod prepare;
-pub use prepare::LevelRun;
+pub use crate::prepare::LevelRun;

--- a/unic/char/basics/src/lib.rs
+++ b/unic/char/basics/src/lib.rs
@@ -69,13 +69,13 @@
 extern crate core;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod noncharacter;
-pub use noncharacter::is_noncharacter;
+pub use crate::noncharacter::is_noncharacter;
 
 pub mod private_use;
-pub use private_use::is_private_use;
+pub use crate::private_use::is_private_use;
 
 pub mod notation;
-pub use notation::unicode_notation;
+pub use crate::notation::unicode_notation;

--- a/unic/char/property/src/lib.rs
+++ b/unic/char/property/src/lib.rs
@@ -36,13 +36,13 @@
 extern crate unic_char_range;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod property;
 pub use self::property::{CharProperty, PartialCharProperty, TotalCharProperty};
 
 mod range_types;
-pub use range_types::{
+pub use crate::range_types::{
     BinaryCharProperty,
     CustomCharProperty,
     EnumeratedCharProperty,

--- a/unic/char/range/src/iter.rs
+++ b/unic/char/range/src/iter.rs
@@ -10,7 +10,7 @@
 
 use core::{char, ops};
 
-use {step, CharRange};
+use crate::{step, CharRange};
 
 const SURROGATE_RANGE: ops::Range<u32> = 0xD800..0xE000;
 

--- a/unic/char/range/src/lib.rs
+++ b/unic/char/range/src/lib.rs
@@ -60,13 +60,13 @@
 extern crate core;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod iter;
-pub use iter::CharIter;
+pub use crate::iter::CharIter;
 
 mod range;
-pub use range::CharRange;
+pub use crate::range::CharRange;
 
 #[macro_use]
 mod macros;

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -14,7 +14,7 @@ use core::{char, cmp};
 use std::collections::Bound;
 
 use self::cmp::Ordering;
-use CharIter;
+use crate::CharIter;
 
 /// A range of unicode code points.
 ///

--- a/unic/char/src/lib.rs
+++ b/unic/char/src/lib.rs
@@ -27,4 +27,4 @@ pub extern crate unic_char_property as property;
 pub extern crate unic_char_range as range;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/common/src/lib.rs
+++ b/unic/common/src/lib.rs
@@ -27,6 +27,6 @@
 //!  components.
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod version;

--- a/unic/emoji/char/src/lib.rs
+++ b/unic/emoji/char/src/lib.rs
@@ -28,22 +28,22 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod emoji_version;
-pub use emoji_version::{UnicodeVersion, EMOJI_VERSION};
+pub use crate::emoji_version::{UnicodeVersion, EMOJI_VERSION};
 
 mod emoji;
-pub use emoji::{is_emoji, Emoji};
+pub use crate::emoji::{is_emoji, Emoji};
 
 mod emoji_component;
-pub use emoji_component::{is_emoji_component, EmojiComponent};
+pub use crate::emoji_component::{is_emoji_component, EmojiComponent};
 
 mod emoji_modifier;
-pub use emoji_modifier::{is_emoji_modifier, EmojiModifier};
+pub use crate::emoji_modifier::{is_emoji_modifier, EmojiModifier};
 
 mod emoji_modifier_base;
-pub use emoji_modifier_base::{is_emoji_modifier_base, EmojiModifierBase};
+pub use crate::emoji_modifier_base::{is_emoji_modifier_base, EmojiModifierBase};
 
 mod emoji_presentation;
-pub use emoji_presentation::{is_emoji_presentation, EmojiPresentation};
+pub use crate::emoji_presentation::{is_emoji_presentation, EmojiPresentation};

--- a/unic/emoji/src/lib.rs
+++ b/unic/emoji/src/lib.rs
@@ -27,6 +27,6 @@
 pub extern crate unic_emoji_char as char;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
-pub use char::EMOJI_VERSION;
+pub use crate::char::EMOJI_VERSION;

--- a/unic/idna/mapping/src/lib.rs
+++ b/unic/idna/mapping/src/lib.rs
@@ -34,9 +34,9 @@ mod mapping;
 use unic_ucd_version::UnicodeVersion;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
-pub use mapping::Mapping;
+pub use crate::mapping::Mapping;
 
 /// The version of [Unicode IDNA Compatibility Processing](https://www.unicode.org/reports/tr46/)
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/idna/punycode/src/lib.rs
+++ b/unic/idna/punycode/src/lib.rs
@@ -33,7 +33,7 @@ use std::char;
 use std::u32;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 // Bootstring parameters for Punycode
 static BASE: u32 = 36;

--- a/unic/idna/src/lib.rs
+++ b/unic/idna/src/lib.rs
@@ -56,11 +56,11 @@ extern crate unic_idna_mapping as mapping;
 extern crate unic_idna_punycode as punycode;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
-pub use mapping::UNICODE_VERSION;
+pub use crate::mapping::UNICODE_VERSION;
 
 mod process;
-pub use process::PUNYCODE_PREFIX;
-pub use process::{to_ascii, to_unicode};
-pub use process::{Errors, Flags};
+pub use crate::process::PUNYCODE_PREFIX;
+pub use crate::process::{to_ascii, to_unicode};
+pub use crate::process::{Errors, Flags};

--- a/unic/idna/src/process.rs
+++ b/unic/idna/src/process.rs
@@ -13,8 +13,8 @@ use unic_normal::StrNormalForm;
 use unic_ucd_bidi::{bidi_class, BidiClass};
 use unic_ucd_normal::is_combining_mark;
 
-use mapping::Mapping;
-use punycode;
+use crate::mapping::Mapping;
+use crate::punycode;
 
 /// Prefix used in Punycode encoding.
 pub static PUNYCODE_PREFIX: &'static str = "xn--";

--- a/unic/normal/src/lib.rs
+++ b/unic/normal/src/lib.rs
@@ -44,12 +44,12 @@ mod recompose;
 
 use std::str::Chars;
 
-pub use decompose::Decompositions;
-pub use recompose::Recompositions;
+pub use crate::decompose::Decompositions;
+pub use crate::recompose::Recompositions;
 pub use unic_ucd_normal::UNICODE_VERSION;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 /// Methods for iterating over strings while applying Unicode normalizations
 /// as described in

--- a/unic/normal/src/recompose.rs
+++ b/unic/normal/src/recompose.rs
@@ -14,7 +14,7 @@ use std::fmt::{self, Write};
 
 use unic_ucd_normal::{compose, CanonicalCombiningClass};
 
-use decompose::Decompositions;
+use crate::decompose::Decompositions;
 
 #[derive(Clone, Debug)]
 enum RecompositionState {

--- a/unic/segment/src/lib.rs
+++ b/unic/segment/src/lib.rs
@@ -87,10 +87,10 @@ extern crate unic_ucd_common;
 pub use unic_ucd_segment::UNICODE_VERSION;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod grapheme;
-pub use grapheme::{GraphemeCursor, GraphemeIncomplete, GraphemeIndices, Graphemes};
+pub use crate::grapheme::{GraphemeCursor, GraphemeIncomplete, GraphemeIndices, Graphemes};
 
 mod word;
-pub use word::{WordBoundIndices, WordBounds, Words};
+pub use crate::word::{WordBoundIndices, WordBounds, Words};

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -181,7 +181,7 @@ pub extern crate unic_segment as segment;
 pub extern crate unic_ucd as ucd;
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
-pub use ucd::UNICODE_VERSION;
+pub use crate::ucd::UNICODE_VERSION;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/ucd/age/src/lib.rs
+++ b/unic/ucd/age/src/lib.rs
@@ -35,10 +35,10 @@ extern crate unic_ucd_version;
 pub use unic_ucd_version::UnicodeVersion;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod age;
-pub use age::{Age, CharAge};
+pub use crate::age::{Age, CharAge};
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/ucd/bidi/src/lib.rs
+++ b/unic/ucd/bidi/src/lib.rs
@@ -34,16 +34,16 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod bidi_class;
-pub use bidi_class::{BidiClass, BidiClassCategory, CharBidiClass, StrBidiClass};
+pub use crate::bidi_class::{BidiClass, BidiClassCategory, CharBidiClass, StrBidiClass};
 
 pub mod bidi_control;
-pub use bidi_control::{is_bidi_control, BidiControl};
+pub use crate::bidi_control::{is_bidi_control, BidiControl};
 
 pub mod bidi_mirrored;
-pub use bidi_mirrored::{is_bidi_mirrored, BidiMirrored};
+pub use crate::bidi_mirrored::{is_bidi_mirrored, BidiMirrored};
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/case/src/lib.rs
+++ b/unic/ucd/case/src/lib.rs
@@ -34,34 +34,34 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod lowercase;
-pub use lowercase::{is_lowercase, Lowercase};
+pub use crate::lowercase::{is_lowercase, Lowercase};
 
 pub mod uppercase;
-pub use uppercase::{is_uppercase, Uppercase};
+pub use crate::uppercase::{is_uppercase, Uppercase};
 
 pub mod cased;
-pub use cased::{is_cased, Cased};
+pub use crate::cased::{is_cased, Cased};
 
 pub mod case_ignorable;
-pub use case_ignorable::{is_case_ignorable, CaseIgnorable};
+pub use crate::case_ignorable::{is_case_ignorable, CaseIgnorable};
 
 pub mod changes_when_lowercased;
-pub use changes_when_lowercased::{changes_when_lowercased, ChangesWhenLowercased};
+pub use crate::changes_when_lowercased::{changes_when_lowercased, ChangesWhenLowercased};
 
 pub mod changes_when_uppercased;
-pub use changes_when_uppercased::{changes_when_uppercased, ChangesWhenUppercased};
+pub use crate::changes_when_uppercased::{changes_when_uppercased, ChangesWhenUppercased};
 
 pub mod changes_when_titlecased;
-pub use changes_when_titlecased::{changes_when_titlecased, ChangesWhenTitlecased};
+pub use crate::changes_when_titlecased::{changes_when_titlecased, ChangesWhenTitlecased};
 
 pub mod changes_when_casefolded;
-pub use changes_when_casefolded::{changes_when_casefolded, ChangesWhenCasefolded};
+pub use crate::changes_when_casefolded::{changes_when_casefolded, ChangesWhenCasefolded};
 
 pub mod changes_when_casemapped;
-pub use changes_when_casemapped::{changes_when_casemapped, ChangesWhenCasemapped};
+pub use crate::changes_when_casemapped::{changes_when_casemapped, ChangesWhenCasemapped};
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/category/src/lib.rs
+++ b/unic/ucd/category/src/lib.rs
@@ -54,10 +54,10 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod category;
-pub use category::GeneralCategory;
+pub use crate::category::GeneralCategory;
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/common/src/lib.rs
+++ b/unic/ucd/common/src/lib.rs
@@ -33,26 +33,26 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 // == UCD-defined: types and methods ==
 
 pub mod alphabetic;
-pub use alphabetic::{is_alphabetic, Alphabetic};
+pub use crate::alphabetic::{is_alphabetic, Alphabetic};
 
 pub mod white_space;
-pub use white_space::{is_white_space, WhiteSpace};
+pub use crate::white_space::{is_white_space, WhiteSpace};
 
 // == Non-UCD-defined: methods only ==
 
 pub mod alphanumeric;
-pub use alphanumeric::is_alphanumeric;
+pub use crate::alphanumeric::is_alphanumeric;
 
 pub mod control;
-pub use control::is_control;
+pub use crate::control::is_control;
 
 pub mod numeric;
-pub use numeric::is_numeric;
+pub use crate::numeric::is_numeric;
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/hangul/src/lib.rs
+++ b/unic/ucd/hangul/src/lib.rs
@@ -51,10 +51,10 @@ extern crate unic_ucd_version;
 use unic_ucd_version::UnicodeVersion;
 
 mod hangul;
-pub use hangul::{compose_syllable, decompose_syllable, is_syllable};
+pub use crate::hangul::{compose_syllable, decompose_syllable, is_syllable};
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
 pub const UNICODE_VERSION: UnicodeVersion = include!("../tables/unicode_version.rsv");

--- a/unic/ucd/ident/src/lib.rs
+++ b/unic/ucd/ident/src/lib.rs
@@ -41,7 +41,7 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 #[cfg(feature = "xid")]
 mod xid {
@@ -73,7 +73,7 @@ mod xid {
     }
 }
 #[cfg(feature = "xid")]
-pub use xid::{is_xid_continue, is_xid_start, XidContinue, XidStart};
+pub use crate::xid::{is_xid_continue, is_xid_start, XidContinue, XidStart};
 
 #[cfg(feature = "id")]
 mod id {

--- a/unic/ucd/name/src/lib.rs
+++ b/unic/ucd/name/src/lib.rs
@@ -29,10 +29,10 @@ extern crate unic_ucd_hangul;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod name;
-pub use name::Name;
+pub use crate::name::Name;
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -12,9 +12,9 @@
 use unic_char_property::tables::CharDataTable;
 
 pub mod data {
-    use decomposition_type::long_names::*;
+    use crate::decomposition_type::long_names::*;
     use unic_char_property::tables::CharDataTable;
-    use DecompositionType;
+    use crate::DecompositionType;
 
     pub const CANONICAL_COMPOSITION_MAPPING: CharDataTable<CharDataTable<char>> =
         include!("../tables/canonical_composition_mapping.rsv");

--- a/unic/ucd/normal/src/decomposition.rs
+++ b/unic/ucd/normal/src/decomposition.rs
@@ -11,7 +11,7 @@
 
 use core::ops::FnMut;
 
-use composition::{canonical_decomposition, compatibility_decomposition};
+use crate::composition::{canonical_decomposition, compatibility_decomposition};
 
 use unic_ucd_hangul::{decompose_syllable, is_syllable};
 

--- a/unic/ucd/normal/src/decomposition_type.rs
+++ b/unic/ucd/normal/src/decomposition_type.rs
@@ -14,7 +14,7 @@
 use unic_char_property::PartialCharProperty;
 use unic_ucd_hangul::is_syllable;
 
-use composition::{canonical_decomposition, data};
+use crate::composition::{canonical_decomposition, data};
 
 char_property! {
     /// Represents the Unicode character

--- a/unic/ucd/normal/src/lib.rs
+++ b/unic/ucd/normal/src/lib.rs
@@ -43,26 +43,26 @@ extern crate unic_ucd_hangul;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod canonical_combining_class;
-pub use canonical_combining_class::CanonicalCombiningClass;
+pub use crate::canonical_combining_class::CanonicalCombiningClass;
 
 mod composition;
-pub use composition::{
+pub use crate::composition::{
     canonical_composition,
     canonical_decomposition,
     compatibility_decomposition,
 };
 
 mod decomposition;
-pub use decomposition::{decompose_canonical, decompose_compatible};
+pub use crate::decomposition::{decompose_canonical, decompose_compatible};
 
 mod gen_cat;
-pub use gen_cat::is_combining_mark;
+pub use crate::gen_cat::is_combining_mark;
 
 mod decomposition_type;
-pub use decomposition_type::DecompositionType;
+pub use crate::decomposition_type::DecompositionType;
 
 use unic_ucd_hangul::compose_syllable;
 

--- a/unic/ucd/segment/src/lib.rs
+++ b/unic/ucd/segment/src/lib.rs
@@ -33,16 +33,16 @@ extern crate unic_char_range;
 extern crate unic_ucd_version;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 pub mod grapheme_cluster_break;
-pub use grapheme_cluster_break::GraphemeClusterBreak;
+pub use crate::grapheme_cluster_break::GraphemeClusterBreak;
 
 pub mod sentence_break;
-pub use sentence_break::SentenceBreak;
+pub use crate::sentence_break::SentenceBreak;
 
 pub mod word_break;
-pub use word_break::WordBreak;
+pub use crate::word_break::WordBreak;
 
 use unic_ucd_version::UnicodeVersion;
 

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -36,16 +36,16 @@ pub extern crate unic_ucd_normal as normal;
 pub extern crate unic_ucd_segment as segment;
 pub extern crate unic_ucd_version as version;
 
-pub use version::UnicodeVersion;
+pub use crate::version::UnicodeVersion;
 
 /// The [Unicode version](https://www.unicode.org/versions/) of data
-pub use version::UNICODE_VERSION;
+pub use crate::version::UNICODE_VERSION;
 
-pub use age::{Age, CharAge};
+pub use crate::age::{Age, CharAge};
 
-pub use bidi::{is_bidi_mirrored, BidiClass, CharBidiClass, StrBidiClass};
+pub use crate::bidi::{is_bidi_mirrored, BidiClass, CharBidiClass, StrBidiClass};
 
-pub use case::{
+pub use crate::case::{
     changes_when_casefolded,
     changes_when_casemapped,
     changes_when_lowercased,
@@ -66,15 +66,15 @@ pub use case::{
     Uppercase,
 };
 
-pub use category::GeneralCategory;
+pub use crate::category::GeneralCategory;
 
-pub use common::{is_alphabetic, is_white_space, Alphabetic, WhiteSpace};
+pub use crate::common::{is_alphabetic, is_white_space, Alphabetic, WhiteSpace};
 
-pub use name::Name;
+pub use crate::name::Name;
 
-pub use normal::CanonicalCombiningClass;
+pub use crate::normal::CanonicalCombiningClass;
 
-pub use segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
+pub use crate::segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};

--- a/unic/ucd/version/src/lib.rs
+++ b/unic/ucd/version/src/lib.rs
@@ -29,7 +29,7 @@ extern crate unic_common;
 pub use unic_common::version::UnicodeVersion;
 
 mod pkg_info;
-pub use pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
+pub use crate::pkg_info::{PKG_DESCRIPTION, PKG_NAME, PKG_VERSION};
 
 mod unicode_version;
-pub use unicode_version::UNICODE_VERSION;
+pub use crate::unicode_version::UNICODE_VERSION;


### PR DESCRIPTION
This pull request fixes build warnings related to module paths in `use` declarations for beta and nightly toolchains.