### PR TITLE
Clippy fixes and changing refs to Copy

### DIFF
--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -278,7 +278,7 @@ impl<'text> BidiInfo<'text> {
     /// `line` is a range of bytes indices within `levels`.
     ///
     /// <https://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels>
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+    #[allow(clippy::needless_range_loop)]
     pub fn visual_runs(
         &self,
         para: &ParagraphInfo,

--- a/unic/bidi/src/implicit.rs
+++ b/unic/bidi/src/implicit.rs
@@ -74,7 +74,7 @@ pub fn resolve_weak(sequence: &IsolatingRunSequence, processing_classes: &mut [B
                 let next_class = indices
                     .clone()
                     .map(|j| processing_classes[j])
-                    .find(not_removed_by_x9)
+                    .find(|&x| not_removed_by_x9(x))
                     .unwrap_or(sequence.eos);
                 processing_classes[i] = match (prev_class, processing_classes[i], next_class) {
                     (EN, ES, EN) | (EN, CS, EN) => EN,

--- a/unic/bidi/src/level.rs
+++ b/unic/bidi/src/level.rs
@@ -102,19 +102,19 @@ impl Level {
 
     /// The level number.
     #[inline]
-    pub fn number(&self) -> u8 {
+    pub fn number(self) -> u8 {
         self.0
     }
 
     /// If this level is left-to-right.
     #[inline]
-    pub fn is_ltr(&self) -> bool {
+    pub fn is_ltr(self) -> bool {
         self.0 % 2 == 0
     }
 
     /// If this level is right-to-left.
     #[inline]
-    pub fn is_rtl(&self) -> bool {
+    pub fn is_rtl(self) -> bool {
         self.0 % 2 == 1
     }
 
@@ -168,26 +168,26 @@ impl Level {
 
     /// The next LTR (even) level greater than this, or fail if number is larger than `max_depth`.
     #[inline]
-    pub fn new_explicit_next_ltr(&self) -> Result<Level, Error> {
+    pub fn new_explicit_next_ltr(self) -> Result<Level, Error> {
         Level::new_explicit((self.0 + 2) & !1)
     }
 
     /// The next RTL (odd) level greater than this, or fail if number is larger than `max_depth`.
     #[inline]
-    pub fn new_explicit_next_rtl(&self) -> Result<Level, Error> {
+    pub fn new_explicit_next_rtl(self) -> Result<Level, Error> {
         Level::new_explicit((self.0 + 1) | 1)
     }
 
     /// The lowest RTL (odd) level greater than or equal to this, or fail if number is larger than
     /// `max_depth + 1`.
     #[inline]
-    pub fn new_lowest_ge_rtl(&self) -> Result<Level, Error> {
+    pub fn new_lowest_ge_rtl(self) -> Result<Level, Error> {
         Level::new(self.0 | 1)
     }
 
     /// Generate a character type based on a level (as specified in steps X10 and N2).
     #[inline]
-    pub fn bidi_class(&self) -> BidiClass {
+    pub fn bidi_class(self) -> BidiClass {
         if self.is_rtl() {
             BidiClass::RightToLeft
         } else {

--- a/unic/bidi/src/prepare.rs
+++ b/unic/bidi/src/prepare.rs
@@ -41,6 +41,7 @@ pub struct IsolatingRunSequence {
 /// whose matching PDI is the first character of the next level run in the sequence.
 ///
 /// Note: This function does *not* return the sequences in order by their first characters.
+#[allow(clippy::len_zero)]
 pub fn isolating_run_sequences(
     para_level: Level,
     original_classes: &[BidiClass],
@@ -98,7 +99,7 @@ pub fn isolating_run_sequences(
             #[cfg(test)]
             for run in sequence.clone() {
                 for idx in run {
-                    if not_removed_by_x9(&original_classes[idx]) {
+                    if not_removed_by_x9(original_classes[idx]) {
                         assert_eq!(seq_level, levels[idx]);
                     }
                 }
@@ -107,7 +108,7 @@ pub fn isolating_run_sequences(
             // Get the level of the last non-removed char before the runs.
             let pred_level = match original_classes[..start_of_seq]
                 .iter()
-                .rposition(not_removed_by_x9)
+                .rposition(|&x| not_removed_by_x9(x))
             {
                 Some(idx) => levels[idx],
                 None => para_level,
@@ -119,7 +120,7 @@ pub fn isolating_run_sequences(
             } else {
                 match original_classes[end_of_seq..]
                     .iter()
-                    .position(not_removed_by_x9)
+                    .position(|&x| not_removed_by_x9(x))
                 {
                     Some(idx) => levels[end_of_seq + idx],
                     None => para_level,
@@ -169,8 +170,8 @@ pub fn removed_by_x9(class: BidiClass) -> bool {
 }
 
 // For use as a predicate for `position` / `rposition`
-pub fn not_removed_by_x9(class: &BidiClass) -> bool {
-    !removed_by_x9(*class)
+pub fn not_removed_by_x9(class: BidiClass) -> bool {
+    !removed_by_x9(class)
 }
 
 #[cfg(test)]
@@ -187,7 +188,7 @@ mod tests {
     }
 
     // From <https://www.unicode.org/reports/tr9/#BD13>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn test_isolating_run_sequences() {
 
@@ -232,7 +233,7 @@ mod tests {
     }
 
     // From <https://www.unicode.org/reports/tr9/#X10>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn test_isolating_run_sequences_sos_and_eos() {
 
@@ -363,7 +364,7 @@ mod tests {
             L, R, AL, EN, ES, ET, AN, CS, NSM, B, S, WS, ON, LRI, RLI, FSI, PDI,
         ];
         for x in non_x9_classes {
-            assert_eq!(not_removed_by_x9(&x), true);
+            assert_eq!(not_removed_by_x9(*x), true);
         }
     }
 }

--- a/unic/char/property/src/range_types.rs
+++ b/unic/char/property/src/range_types.rs
@@ -88,7 +88,7 @@ impl NumericCharPropertyValue for u8 {}
 /// Examples: `Numeric_Value`, `Canonical_Combining_Class`
 pub trait NumericCharProperty<NumericValue: NumericCharPropertyValue>: CharProperty {
     /// The numeric value for the property value.
-    fn number(&self) -> NumericValue;
+    fn number(self) -> NumericValue;
 }
 
 // == Custom Types ==
@@ -100,5 +100,5 @@ pub trait NumericCharProperty<NumericValue: NumericCharPropertyValue>: CharPrope
 /// Examples: `Age` property that returns a `UnicodeVersion` value.
 pub trait CustomCharProperty<Value>: CharProperty {
     /// The actual (inner) value for the property value.
-    fn actual(&self) -> Value;
+    fn actual(self) -> Value;
 }

--- a/unic/char/range/src/iter.rs
+++ b/unic/char/range/src/iter.rs
@@ -131,6 +131,7 @@ impl DoubleEndedIterator for CharIter {
     }
 }
 
+#[allow(clippy::range_plus_one)] // RangeInclusive<u32> does not impl ExactSizeIterator
 impl ExactSizeIterator for CharIter {
     fn len(&self) -> usize {
         if self.is_finished() {

--- a/unic/char/range/src/range.rs
+++ b/unic/char/range/src/range.rs
@@ -177,7 +177,7 @@ impl CharRange {
     /// assert!( ! CharRange:: open ('a', 'a').contains('a'));
     /// assert!( ! CharRange::closed('z', 'a').contains('g'));
     /// ```
-    pub fn contains(&self, ch: char) -> bool {
+    pub fn contains(self, ch: char) -> bool {
         self.low <= ch && ch <= self.high
     }
 
@@ -187,7 +187,7 @@ impl CharRange {
     ///
     /// Panics if the range is empty. This fn may be adjusted in the future to not panic
     /// in optimized builds. Even if so, an empty range will never compare as `Ordering::Equal`.
-    pub fn cmp_char(&self, ch: char) -> Ordering {
+    pub fn cmp_char(self, ch: char) -> Ordering {
         // possible optimization: only assert this in debug builds
         assert!(!self.is_empty(), "Cannot compare empty range's ordering");
         if self.high < ch {
@@ -200,18 +200,18 @@ impl CharRange {
     }
 
     /// How many characters are in this range?
-    pub fn len(&self) -> usize {
+    pub fn len(self) -> usize {
         self.iter().len()
     }
 
     /// Is this range empty?
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(self) -> bool {
         self.low > self.high
     }
 
     /// Create an iterator over this range.
-    pub fn iter(&self) -> CharIter {
-        (*self).into()
+    pub fn iter(self) -> CharIter {
+        self.into()
     }
 }
 

--- a/unic/idna/mapping/src/mapping.rs
+++ b/unic/idna/mapping/src/mapping.rs
@@ -39,7 +39,7 @@ mod data {
     use super::Mapping::*;
     use unic_char_property::tables::CharDataTable;
 
-    #[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
+    #[allow(clippy::unreadable_literal)]
     pub const MAPPING: CharDataTable<super::Mapping> = include!("../tables/idna_mapping.rsv");
 }
 

--- a/unic/idna/punycode/src/lib.rs
+++ b/unic/idna/punycode/src/lib.rs
@@ -69,7 +69,7 @@ pub fn decode_to_string(input: &str) -> Option<String> {
 /// Return None on malformed input or overflow.
 /// Overflow can only happen on inputs that take more than
 /// 63 encoded bytes, the DNS limit on domain name labels.
-#[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
+#[allow(clippy::cast_lossless)]
 pub fn decode(input: &str) -> Option<Vec<char>> {
     // Handle "basic" (ASCII) code points.
     // They are encoded as-is before the last delimiter, if any.

--- a/unic/idna/src/process.rs
+++ b/unic/idna/src/process.rs
@@ -159,7 +159,7 @@ fn passes_bidi(label: &str, is_bidi_domain: bool) -> bool {
 }
 
 // https://www.unicode.org/reports/tr46/#Validity_Criteria
-#[cfg_attr(feature = "cargo-clippy", allow(if_same_then_else))]
+#[allow(clippy::if_same_then_else)]
 fn validate(label: &str, is_bidi_domain: bool, flags: Flags, errors: &mut Vec<Error>) {
     let first_char = label.chars().next();
 
@@ -296,7 +296,7 @@ pub struct Flags {
 }
 
 /// Error types recorded during UTS #46 processing.
-#[cfg_attr(feature = "cargo-clippy", allow(enum_variant_names))]
+#[allow(clippy::enum_variant_names)]
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 enum Error {
     PunycodeError,

--- a/unic/segment/src/grapheme.rs
+++ b/unic/segment/src/grapheme.rs
@@ -273,7 +273,7 @@ enum PairResult {
 fn check_pair(before: GCB, after: GCB) -> PairResult {
     use self::PairResult::*;
 
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[allow(clippy::match_same_arms)]
     match (before, after) {
         // Do not break between a CR and LF. Otherwise, break before and after controls.
         (GCB::CR, GCB::LF) => NotBreak, // GB3
@@ -533,7 +533,7 @@ impl GraphemeCursor {
     // TODO(clippy): Fix clippy warning or leave it as allowed if really needed.
     // `warning: methods called `is_*` usually take self by reference or no self; consider choosing
     // a less ambiguous name`
-    #[cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]
+    #[allow(clippy::wrong_self_convention)]
     /// Determine whether the current cursor location is a grapheme cluster boundary.
     /// Only a part of the string need be supplied. If `chunk_start` is nonzero or
     /// the length of `chunk` is not equal to `len` on creation, then this method

--- a/unic/segment/src/word.rs
+++ b/unic/segment/src/word.rs
@@ -168,7 +168,7 @@ impl<'a> Iterator for WordBounds<'a> {
     }
 
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[allow(clippy::match_same_arms, clippy::cyclomatic_complexity)]
     fn next(&mut self) -> Option<&'a str> {
         use self::FormatExtendType::*;
         use self::WordBoundsState::*;
@@ -401,7 +401,7 @@ impl<'a> Iterator for WordBounds<'a> {
 
 impl<'a> DoubleEndedIterator for WordBounds<'a> {
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
+    #[allow(clippy::cyclomatic_complexity)]
     fn next_back(&mut self) -> Option<&'a str> {
         use self::FormatExtendType::*;
         use self::WordBoundsState::*;

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -61,7 +61,7 @@ impl PartialCharProperty for Age {
 impl CustomCharProperty<UnicodeVersion> for Age {
     /// Get numeric value for character property value
     fn actual(&self) -> UnicodeVersion {
-        Self::actual(self)
+        Self::actual(*self) // TODO: Should we change the trait to take `self` instead?
     }
 }
 
@@ -78,7 +78,7 @@ impl Age {
     }
 
     /// Return the `UnicodeVersion` value of the age.
-    pub fn actual(&self) -> UnicodeVersion {
+    pub fn actual(self) -> UnicodeVersion {
         self.0
     }
 }

--- a/unic/ucd/age/src/age.rs
+++ b/unic/ucd/age/src/age.rs
@@ -60,8 +60,8 @@ impl PartialCharProperty for Age {
 
 impl CustomCharProperty<UnicodeVersion> for Age {
     /// Get numeric value for character property value
-    fn actual(&self) -> UnicodeVersion {
-        Self::actual(*self) // TODO: Should we change the trait to take `self` instead?
+    fn actual(self) -> UnicodeVersion {
+        Self::actual(self)
     }
 }
 

--- a/unic/ucd/bidi/src/bidi_class.rs
+++ b/unic/ucd/bidi/src/bidi_class.rs
@@ -236,8 +236,8 @@ impl BidiClass {
 
     /// If the `BidiClass` has strong or explicit Left-to-Right direction.
     #[inline]
-    pub fn category(&self) -> BidiClassCategory {
-        match *self {
+    pub fn category(self) -> BidiClassCategory {
+        match self {
             BidiClass::LeftToRight | BidiClass::RightToLeft | BidiClass::ArabicLetter => {
                 BidiClassCategory::Strong
             }
@@ -269,8 +269,8 @@ impl BidiClass {
 
     /// If the `BidiClass` has strong or explicit Left-to-Right direction.
     #[inline]
-    pub fn is_ltr(&self) -> bool {
-        match *self {
+    pub fn is_ltr(self) -> bool {
+        match self {
             BidiClass::LeftToRight
             | BidiClass::LeftToRightEmbedding
             | BidiClass::LeftToRightOverride
@@ -281,8 +281,8 @@ impl BidiClass {
 
     /// If the `BidiClass` has strong or explicit Right-To-Left direction.
     #[inline]
-    pub fn is_rtl(&self) -> bool {
-        match *self {
+    pub fn is_rtl(self) -> bool {
+        match self {
             BidiClass::RightToLeft
             | BidiClass::ArabicLetter
             | BidiClass::RightToLeftEmbedding

--- a/unic/ucd/category/src/category.rs
+++ b/unic/ucd/category/src/category.rs
@@ -265,51 +265,51 @@ impl GeneralCategory {
 
 impl GeneralCategory {
     /// `Lu` | `Ll` | `Lt`  (Short form: `LC`)
-    pub fn is_cased_letter(&self) -> bool {
+    pub fn is_cased_letter(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Lu | Ll | Lt)
+        matches!(self, Lu | Ll | Lt)
     }
 
     /// `Lu` | `Ll` | `Lt` | `Lm` | `Lo`  (Short form: `L`)
-    pub fn is_letter(&self) -> bool {
+    pub fn is_letter(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Lu | Ll | Lt | Lm | Lo)
+        matches!(self, Lu | Ll | Lt | Lm | Lo)
     }
 
     /// `Mn` | `Mc` | `Me`  (Short form: `M`)
-    pub fn is_mark(&self) -> bool {
+    pub fn is_mark(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Mn | Mc | Me)
+        matches!(self, Mn | Mc | Me)
     }
 
     /// `Nd` | `Nl` | `No`  (Short form: `N`)
-    pub fn is_number(&self) -> bool {
+    pub fn is_number(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Nd | Nl | No)
+        matches!(self, Nd | Nl | No)
     }
 
     /// `Pc` | `Pd` | `Ps` | `Pe` | `Pi` | `Pf` | `Po`  (Short form: `P`)
-    pub fn is_punctuation(&self) -> bool {
+    pub fn is_punctuation(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Pc | Pd | Ps | Pe | Pi | Pf | Po)
+        matches!(self, Pc | Pd | Ps | Pe | Pi | Pf | Po)
     }
 
     /// `Sm` | `Sc` | `Sk` | `So`  (Short form: `S`)
-    pub fn is_symbol(&self) -> bool {
+    pub fn is_symbol(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Sm | Sc | Sk | So)
+        matches!(self, Sm | Sc | Sk | So)
     }
 
     /// `Zs` | `Zl` | `Zp`  (Short form: `Z`)
-    pub fn is_separator(&self) -> bool {
+    pub fn is_separator(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Zs | Zl | Zp)
+        matches!(self, Zs | Zl | Zp)
     }
 
     /// `Cc` | `Cf` | `Cs` | `Co` | `Cn`  (Short form: `C`)
-    pub fn is_other(&self) -> bool {
+    pub fn is_other(self) -> bool {
         use self::abbr_names::*;
-        matches!(*self, Cc | Cf | Cs | Co | Cn)
+        matches!(self, Cc | Cf | Cs | Co | Cn)
     }
 }
 

--- a/unic/ucd/name/src/name.rs
+++ b/unic/ucd/name/src/name.rs
@@ -49,7 +49,7 @@ pub enum Name {
     NR3(&'static [&'static str]),
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]
+#[allow(clippy::len_without_is_empty)]
 impl Name {
     /// Find the character `Name` property value.
     pub fn of(ch: char) -> Option<Name> {
@@ -101,7 +101,7 @@ impl Name {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn number_of_hex_digits(ch: char) -> usize {
         (32 - u32::leading_zeros(ch as u32) as usize + 3) / 4

--- a/unic/ucd/name_aliases/src/name_aliases.rs
+++ b/unic/ucd/name_aliases/src/name_aliases.rs
@@ -62,7 +62,11 @@ mod data {
     // Bring all enum cases into scope, because NameAliasType is omitted
     // in name_alias_types.rsv to save space
     use crate::NameAliasType::{
-        AlternateNames, ControlCodeNames, Figments, NameAbbreviations, NameCorrections,
+        AlternateNames,
+        ControlCodeNames,
+        Figments,
+        NameAbbreviations,
+        NameCorrections,
     };
     pub const NAME_ALIAS_TYPES: CharDataTable<&[crate::NameAliasType]> =
         include!("../tables/name_alias_types.rsv");

--- a/unic/ucd/name_aliases/tests/basic_tests.rs
+++ b/unic/ucd/name_aliases/tests/basic_tests.rs
@@ -14,7 +14,10 @@ use unic_ucd_name_aliases::{name_aliases_of, NameAliasType};
 fn test_name_alias_type_of() {
     assert_eq!(
         NameAliasType::of('\u{0000}').unwrap(),
-        &[NameAliasType::ControlCodeNames, NameAliasType::NameAbbreviations]
+        &[
+            NameAliasType::ControlCodeNames,
+            NameAliasType::NameAbbreviations
+        ]
     );
 
     assert_eq!(
@@ -29,7 +32,10 @@ fn test_name_alias_type_of() {
 
     assert_eq!(
         NameAliasType::of('\u{FEFF}').unwrap(),
-        &[NameAliasType::AlternateNames, NameAliasType::NameAbbreviations]
+        &[
+            NameAliasType::AlternateNames,
+            NameAliasType::NameAbbreviations
+        ]
     );
 
     assert_eq!(
@@ -37,10 +43,7 @@ fn test_name_alias_type_of() {
         &[NameAliasType::NameCorrections]
     );
 
-    assert_eq!(
-        NameAliasType::of('\u{0041}'),
-        None
-    );
+    assert_eq!(NameAliasType::of('\u{0041}'), None);
 }
 
 #[test]

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -45,8 +45,8 @@ impl TotalCharProperty for CanonicalCombiningClass {
 
 impl NumericCharProperty<u8> for CanonicalCombiningClass {
     /// Get numeric value for character property value
-    fn number(&self) -> u8 {
-        Self::number(*self) // TODO: Should we change the trait to take `self` instead?
+    fn number(self) -> u8 {
+        Self::number(self)
     }
 }
 

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -46,7 +46,7 @@ impl TotalCharProperty for CanonicalCombiningClass {
 impl NumericCharProperty<u8> for CanonicalCombiningClass {
     /// Get numeric value for character property value
     fn number(&self) -> u8 {
-        Self::number(self)
+        Self::number(*self) // TODO: Should we change the trait to take `self` instead?
     }
 }
 
@@ -57,7 +57,7 @@ mod data {
         include!("../tables/canonical_combining_class_values.rsv");
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]  // We want the consts ordered by value.
+#[rustfmt::skip] // We want the consts ordered by value.
 #[allow(non_upper_case_globals)]
 impl CanonicalCombiningClass {
     /// Find the character `Canonical_Combining_Class` property value.
@@ -125,17 +125,17 @@ impl fmt::Display for CanonicalCombiningClass {
 
 impl CanonicalCombiningClass {
     /// Get numeric `Canonical_Combining_Class` value
-    pub fn number(&self) -> u8 {
+    pub fn number(self) -> u8 {
         self.0
     }
 
     /// If the *ccc* has value `Not_Reordered` (`0`).
-    pub fn is_not_reordered(&self) -> bool {
+    pub fn is_not_reordered(self) -> bool {
         self.0 == 0
     }
 
     /// If the *ccc* any value other than `Not_Reordered` (`0`).
-    pub fn is_reordered(&self) -> bool {
+    pub fn is_reordered(self) -> bool {
         self.0 != 0
     }
 }

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -22,7 +22,7 @@ pub mod data {
     pub const CANONICAL_DECOMPOSITION_MAPPING: CharDataTable<&[char]> =
         include!("../tables/canonical_decomposition_mapping.rsv");
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     pub const COMPATIBILITY_DECOMPOSITION_MAPPING: CharDataTable<(DecompositionType, &[char])> =
         include!("../tables/compatibility_decomposition_mapping.rsv");
 }

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -79,10 +79,7 @@ pub use crate::name::Name;
 
 pub use crate::normal::CanonicalCombiningClass;
 
-pub use crate::name_aliases::{
-    name_aliases_of,
-    NameAliasType,
-};
+pub use crate::name_aliases::{name_aliases_of, NameAliasType};
 
 pub use crate::segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
 


### PR DESCRIPTION
Updated clippy allows from `cfg_attr` to proc-macro style.
Fixed #241 + more - Changed a few `impl`s to take `self` instead of `&self`, when they are `Copy` types.

`cargo clippy` should run without any warnings now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-i18n/rust-unic/252)
<!-- Reviewable:end -->
