### PR TITLE
ucd/ident: Use correct data table for white_space

### DIFF
--- a/unic/ucd/ident/src/lib.rs
+++ b/unic/ucd/ident/src/lib.rs
@@ -127,7 +127,7 @@ mod pattern {
             long => "Pattern_White_Space";
             human => "Pattern Whitespace";
 
-            data_table_path => "../tables/pattern_syntax.rsv";
+            data_table_path => "../tables/pattern_white_space.rsv";
         }
 
         /// Is this a character that should be treated as whitespace in patterns?


### PR DESCRIPTION
This is a them as https://github.com/open-i18n/rust-unic/pull/253, but fixing the missing underscore in the new table file name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-i18n/rust-unic/255)
<!-- Reviewable:end -->
