### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 
 ## [Unreleased]
-[Unreleased]: https://github.com/open-i18n/rust-unic/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/open-i18n/rust-unic/compare/v0.9.0...HEAD
+
+
+## [v0.9.0] - 2019-03-02
+[v0.9.0]: https://github.com/open-i18n/rust-unic/compare/v0.8.0...v0.9.0
 
 ### Add
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ In `Cargo.toml`:
 
 ```toml
 [dependencies]
-unic = "0.8.0"  # This has Unicode 10.0.0 data and algorithms
+unic = "0.9.0"  # This has Unicode 10.0.0 data and algorithms
 ```
 
 And in `main.rs`:

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -11,7 +11,7 @@ categories = ["internationalization", "text-processing", "parsing", "command-lin
 readme = "README.md"
 
 [dependencies]
-unic = { path = "../../unic/", version = "0.8.0" }
+unic = { path = "../../unic/", version = "0.9.0" }
 
 clap = "2.29"
 lazy_static = "1.0"

--- a/etc/common.sh
+++ b/etc/common.sh
@@ -17,9 +17,9 @@ set -e
 export COMPONENTS="
     unic/common
 
-    unic/char/basics
     unic/char/range
 
+    unic/char/basics
     unic/char/property
 
     unic/char

--- a/etc/common.sh
+++ b/etc/common.sh
@@ -36,6 +36,7 @@ export COMPONENTS="
     unic/ucd/common
     unic/ucd/ident
     unic/ucd/name
+    unic/ucd/name_aliases
     unic/ucd/normal
     unic/ucd/segment
 

--- a/gen/Cargo.toml
+++ b/gen/Cargo.toml
@@ -9,7 +9,7 @@ description = "UNIC — Table Generation"
 publish = false
 
 [dependencies]
-unic-char-range = { path = "../unic/char/range/", version = "0.8.0" }
+unic-char-range = { path = "../unic/char/range/", version = "0.9.0" }
 
 # Command line argument parsing
 clap = "2.29"

--- a/gen/src/source/ucd/name_aliases.rs
+++ b/gen/src/source/ucd/name_aliases.rs
@@ -18,7 +18,7 @@ use regex::Regex;
 use crate::source::utils::read;
 
 // String constants representing name alias types
-// Note: The string corresponds to unic_name_aliases::NameAliasType enum cases
+// Note: The string corresponds to unic_ucd_name_aliases::NameAliasType enum cases
 static TYPE_STR_CORRECTIONS: &str = "NameCorrections";
 static TYPE_STR_CONTROLS: &str = "ControlCodeNames";
 static TYPE_STR_ALTERNATES: &str = "AlternateNames";

--- a/gen/src/source/ucd/name_aliases.rs
+++ b/gen/src/source/ucd/name_aliases.rs
@@ -26,8 +26,11 @@ static TYPE_STR_FIGMENTS: &str = "Figments";
 static TYPE_STR_ABBREVIATIONS: &str = "NameAbbreviations";
 
 lazy_static! {
-    pub static ref NAME_ALIASES_DATA: NameAliasesData =
-        { read("external/unicode/ucd/data/NameAliases.txt").parse().unwrap() };
+    pub static ref NAME_ALIASES_DATA: NameAliasesData = {
+        read("external/unicode/ucd/data/NameAliases.txt")
+            .parse()
+            .unwrap()
+    };
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -54,7 +57,8 @@ impl FromStr for NameAliasesData {
                   ;([[:alnum:]\ \-]*) # alias
                   ;([[:alpha:]]*)     # type
                 ",
-            ).unwrap();
+            )
+            .unwrap();
         }
 
         let mut name_alias_types: BTreeMap<char, Vec<String>> = BTreeMap::default();
@@ -73,9 +77,9 @@ impl FromStr for NameAliasesData {
                     if $map.contains_key(&chr) {
                         if let Some(values) = $map.get_mut(&chr) {
                             // Check for duplications because this macro is also used
-                            // for inserting types strings to name_alias_types. 
-                            // In case of a character having multiple values for the 
-                            // same type, if we don't check for duplications, the type 
+                            // for inserting types strings to name_alias_types.
+                            // In case of a character having multiple values for the
+                            // same type, if we don't check for duplications, the type
                             // string would be inserted more than once.
                             if !values.contains(&$value) {
                                 values.push($value);
@@ -84,7 +88,7 @@ impl FromStr for NameAliasesData {
                     } else {
                         $map.insert(chr, vec![$value]);
                     }
-                }
+                };
             }
 
             let alias = capture[2].to_owned();
@@ -119,7 +123,7 @@ impl FromStr for NameAliasesData {
             controls,
             alternates,
             figments,
-            abbreviations
+            abbreviations,
         })
     }
 }

--- a/gen/src/writer/ucd/name_aliases.rs
+++ b/gen/src/writer/ucd/name_aliases.rs
@@ -27,17 +27,19 @@ fn emit_unified_name_aliases_table(dir: &Path) {
     write(
         dir,
         "name_alias_types.rsv",
-        &NAME_ALIASES_DATA.name_alias_types.to_direct_char_table(|alias_types, f| {
-            write!(
-                f,
-                "&[{}]",
-                alias_types
-                    .iter()
-                    .map(|alias_type_str| format!("{}", alias_type_str.to_owned()))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        }),
+        &NAME_ALIASES_DATA
+            .name_alias_types
+            .to_direct_char_table(|alias_types, f| {
+                write!(
+                    f,
+                    "&[{}]",
+                    alias_types
+                        .iter()
+                        .map(|alias_type_str| format!("{}", alias_type_str.to_owned()))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }),
     );
 }
 
@@ -59,7 +61,7 @@ fn emit_name_aliases_table(dir: &Path) {
                     )
                 }),
             );
-        }
+        };
     }
 
     write_map_to_file!(corrections, "corrections.rsv");

--- a/unic/Cargo.toml
+++ b/unic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -20,17 +20,17 @@ bench_it = ["unic-bidi/bench_it"]
 serde = ["unic-bidi/serde"]
 
 [dependencies]
-unic-bidi = { path = "bidi/", version = "0.8.0" }
-unic-char = { path = "char/", version = "0.8.0", features = ["std"] }
-unic-common = { path = "common/", version = "0.8.0" }
-unic-emoji = { path = "emoji/", version = "0.8.0" }
-unic-idna = { path = "idna/", version = "0.8.0" }
-unic-normal = { path = "normal/", version = "0.8.0" }
-unic-segment = { path = "segment/", version = "0.8.0" }
-unic-ucd = { path = "ucd/", version = "0.8.0" }
+unic-bidi = { path = "bidi/", version = "0.9.0" }
+unic-char = { path = "char/", version = "0.9.0", features = ["std"] }
+unic-common = { path = "common/", version = "0.9.0" }
+unic-emoji = { path = "emoji/", version = "0.9.0" }
+unic-idna = { path = "idna/", version = "0.9.0" }
+unic-normal = { path = "normal/", version = "0.9.0" }
+unic-segment = { path = "segment/", version = "0.9.0" }
+unic-ucd = { path = "ucd/", version = "0.9.0" }
 
 [dev-dependencies]
-unic-char-range = { path = "char/range/", version = "0.8.0" }
+unic-char-range = { path = "char/range/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/bidi/Cargo.toml
+++ b/unic/bidi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-bidi"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -23,12 +23,12 @@ bench_it = []
 [dependencies]
 matches = "0.1"
 serde = { version = ">=0.8, <2.0", optional = true, features = ["derive"] }
-unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.8.0" }
+unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.9.0" }
 
 [dev-dependencies]
 serde_test = ">=0.8, <2.0"
-unic-char-property = { path = "../char/property/", version = "0.8.0" }
-unic-ucd-version = { path = "../ucd/version/", version = "0.8.0" }
+unic-char-property = { path = "../char/property/", version = "0.9.0" }
+unic-ucd-version = { path = "../ucd/version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/char/Cargo.toml
+++ b/unic/char/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-char"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -18,9 +18,9 @@ default = []
 std = ["unic-char-range/std"]
 
 [dependencies]
-unic-char-basics = { path = "basics/", version = "0.8.0" }
-unic-char-property = { path = "property/", version = "0.8.0" }
-unic-char-range = { path = "range/", version = "0.8.0" }
+unic-char-basics = { path = "basics/", version = "0.9.0" }
+unic-char-property = { path = "property/", version = "0.9.0" }
+unic-char-range = { path = "range/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/char/basics/Cargo.toml
+++ b/unic/char/basics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-char-basics"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -14,7 +14,7 @@ readme = "README.md"
 exclude = []
 
 [dev-dependencies]
-unic-char-range = { path = "../range/", version = "0.8.0" }
+unic-char-range = { path = "../range/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/char/property/Cargo.toml
+++ b/unic/char/property/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-char-property"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,7 +13,7 @@ categories = ["internationalization", "text-processing", "parsing"]
 exclude = []
 
 [dependencies]
-unic-char-range = { path = "../range/", version = "0.8.0" }
+unic-char-range = { path = "../range/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-char-range"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"

--- a/unic/common/Cargo.toml
+++ b/unic/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-common"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"

--- a/unic/emoji/Cargo.toml
+++ b/unic/emoji/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-emoji"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,7 +13,7 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-emoji-char = { path = "char/", version = "0.8.0" }
+unic-emoji-char = { path = "char/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/emoji/char/Cargo.toml
+++ b/unic/emoji/char/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-emoji-char"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-version = { path = "../../ucd/version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-version = { path = "../../ucd/version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/idna/Cargo.toml
+++ b/unic/idna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-idna"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -15,12 +15,12 @@ exclude = ["tests/conformance_tests.rs"]
 
 [dependencies]
 matches = "0.1"
-unic-idna-punycode = { path = "punycode/", version = "0.8.0" }
-unic-idna-mapping = { path = "mapping/", version = "0.8.0" }
-unic-normal = { path = "../normal/", version = "0.8.0" }
-unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.8.0" }
-unic-ucd-normal = { path = "../ucd/normal/", version = "0.8.0" }
-unic-ucd-version = { path = "../ucd/version/", version = "0.8.0" }
+unic-idna-punycode = { path = "punycode/", version = "0.9.0" }
+unic-idna-mapping = { path = "mapping/", version = "0.9.0" }
+unic-normal = { path = "../normal/", version = "0.9.0" }
+unic-ucd-bidi = { path = "../ucd/bidi/", version = "0.9.0" }
+unic-ucd-normal = { path = "../ucd/normal/", version = "0.9.0" }
+unic-ucd-version = { path = "../ucd/version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/idna/mapping/Cargo.toml
+++ b/unic/idna/mapping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-idna-mapping"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-range = { path = "../../char/range/", version = "0.8.0" }
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-ucd-version = { path = "../../ucd/version/", version = "0.8.0" }
+unic-char-range = { path = "../../char/range/", version = "0.9.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-ucd-version = { path = "../../ucd/version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/idna/punycode/Cargo.toml
+++ b/unic/idna/punycode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-idna-punycode"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"

--- a/unic/normal/Cargo.toml
+++ b/unic/normal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-normal"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -14,10 +14,10 @@ readme = "README.md"
 exclude = ["tests/conformance_tests.rs"]
 
 [dependencies]
-unic-ucd-normal = { path = "../ucd/normal/", version = "0.8.0" }
+unic-ucd-normal = { path = "../ucd/normal/", version = "0.9.0" }
 
 [dev-dependencies]
-unic-ucd-version = { path = "../ucd/version/", version = "0.8.0" }
+unic-ucd-version = { path = "../ucd/version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/segment/Cargo.toml
+++ b/unic/segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-segment"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -14,11 +14,11 @@ readme = "README.md"
 exclude = []
 
 [dependencies]
-unic-ucd-segment = { path = "../ucd/segment/", version = "0.8.0" }
+unic-ucd-segment = { path = "../ucd/segment/", version = "0.9.0" }
 
 [dev-dependencies]
 quickcheck = "0.6"
-unic-ucd-common = { path = "../ucd/common/", version = "0.8.0" }
+unic-ucd-common = { path = "../ucd/common/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -14,25 +14,25 @@ readme = "README.md"
 exclude = []
 
 [dependencies]
-unic-ucd-age = { path = "age/", version = "0.8.0" }
-unic-ucd-bidi = { path = "bidi/", version = "0.8.0" }
-unic-ucd-block = { path = "block/", version = "0.8.0" }
-unic-ucd-case = { path = "case/", version = "0.8.0" }
-unic-ucd-category = { path = "category/", version = "0.8.0" }
-unic-ucd-common = { path = "common/", version = "0.8.0" }
-unic-ucd-hangul = { path = "hangul/", version= "0.8.0" }
-unic-ucd-ident = { path = "ident/", version = "0.8.0" }
-unic-ucd-name = { path = "name/", version = "0.8.0" }
-unic-ucd-name_aliases = { path = "name_aliases/", version = "0.8.0" }
-unic-ucd-normal = { path = "normal/", version = "0.8.0", features = ["unic-ucd-category"] }
-unic-ucd-segment = { path = "segment/", version = "0.8.0" }
-unic-ucd-version = { path = "version/", version = "0.8.0" }
+unic-ucd-age = { path = "age/", version = "0.9.0" }
+unic-ucd-bidi = { path = "bidi/", version = "0.9.0" }
+unic-ucd-block = { path = "block/", version = "0.9.0" }
+unic-ucd-case = { path = "case/", version = "0.9.0" }
+unic-ucd-category = { path = "category/", version = "0.9.0" }
+unic-ucd-common = { path = "common/", version = "0.9.0" }
+unic-ucd-hangul = { path = "hangul/", version= "0.9.0" }
+unic-ucd-ident = { path = "ident/", version = "0.9.0" }
+unic-ucd-name = { path = "name/", version = "0.9.0" }
+unic-ucd-name_aliases = { path = "name_aliases/", version = "0.9.0" }
+unic-ucd-normal = { path = "normal/", version = "0.9.0", features = ["unic-ucd-category"] }
+unic-ucd-segment = { path = "segment/", version = "0.9.0" }
+unic-ucd-version = { path = "version/", version = "0.9.0" }
 
 [dev-dependencies]
 matches = "0.1"
-unic-char-basics = { path = "../char/basics/", version = "0.8.0" }
-unic-char-property = { path = "../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../char/range/", version = "0.8.0" }
+unic-char-basics = { path = "../char/basics/", version = "0.9.0" }
+unic-char-property = { path = "../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../char/range/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/age/Cargo.toml
+++ b/unic/ucd/age/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-age"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/bidi/Cargo.toml
+++ b/unic/ucd/bidi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-bidi"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/block/Cargo.toml
+++ b/unic/ucd/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-block"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range/", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range/", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/case/Cargo.toml
+++ b/unic/ucd/case/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-case"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range/", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range/", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-category"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -14,9 +14,9 @@ exclude = []
 
 [dependencies]
 matches = "0.1"
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/common/Cargo.toml
+++ b/unic/ucd/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-common"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,12 +13,12 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [dev-dependencies]
-unic-ucd-category = { path = "../category/", version = "0.8.0" }
+unic-ucd-category = { path = "../category/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/hangul/Cargo.toml
+++ b/unic/ucd/hangul/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-hangul"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,7 +13,7 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/ident/Cargo.toml
+++ b/unic/ucd/ident/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-ident"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -20,12 +20,12 @@ xid = []
 id = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [dev-dependencies]
-unic-ucd-category = { path = "../category/", version = "0.8.0" }
+unic-ucd-category = { path = "../category/", version = "0.9.0" }
 regex = "0.2"
 matches = "0.1"
 

--- a/unic/ucd/name/Cargo.toml
+++ b/unic/ucd/name/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-name"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
-unic-ucd-hangul = { path = "../hangul/", version = "0.8.0" }
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
+unic-ucd-hangul = { path = "../hangul/", version = "0.9.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/name_aliases/Cargo.toml
+++ b/unic/ucd/name_aliases/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-name_aliases"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,8 +13,8 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/name_aliases/src/name_aliases.rs
+++ b/unic/ucd/name_aliases/src/name_aliases.rs
@@ -62,7 +62,11 @@ mod data {
     // Bring all enum cases into scope, because NameAliasType is omitted
     // in name_alias_types.rsv to save space
     use crate::NameAliasType::{
-        AlternateNames, ControlCodeNames, Figments, NameAbbreviations, NameCorrections,
+        AlternateNames,
+        ControlCodeNames,
+        Figments,
+        NameAbbreviations,
+        NameCorrections,
     };
     pub const NAME_ALIAS_TYPES: CharDataTable<&[crate::NameAliasType]> =
         include!("../tables/name_alias_types.rsv");

--- a/unic/ucd/name_aliases/tests/basic_tests.rs
+++ b/unic/ucd/name_aliases/tests/basic_tests.rs
@@ -14,7 +14,10 @@ use unic_ucd_name_aliases::{name_aliases_of, NameAliasType};
 fn test_name_alias_type_of() {
     assert_eq!(
         NameAliasType::of('\u{0000}').unwrap(),
-        &[NameAliasType::ControlCodeNames, NameAliasType::NameAbbreviations]
+        &[
+            NameAliasType::ControlCodeNames,
+            NameAliasType::NameAbbreviations
+        ]
     );
 
     assert_eq!(
@@ -29,7 +32,10 @@ fn test_name_alias_type_of() {
 
     assert_eq!(
         NameAliasType::of('\u{FEFF}').unwrap(),
-        &[NameAliasType::AlternateNames, NameAliasType::NameAbbreviations]
+        &[
+            NameAliasType::AlternateNames,
+            NameAliasType::NameAbbreviations
+        ]
     );
 
     assert_eq!(
@@ -37,10 +43,7 @@ fn test_name_alias_type_of() {
         &[NameAliasType::NameCorrections]
     );
 
-    assert_eq!(
-        NameAliasType::of('\u{0041}'),
-        None
-    );
+    assert_eq!(NameAliasType::of('\u{0041}'), None);
 }
 
 #[test]

--- a/unic/ucd/normal/Cargo.toml
+++ b/unic/ucd/normal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-normal"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,14 +13,14 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = ["tests/conformance_tests.rs"]
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-category = { path = "../category/", version = "0.8.0", optional = true }
-unic-ucd-hangul = { path = "../hangul/", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-category = { path = "../category/", version = "0.9.0", optional = true }
+unic-ucd-hangul = { path = "../hangul/", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [dev-dependencies]
-unic-ucd-category = { path = "../category/", version = "0.8.0" }
+unic-ucd-category = { path = "../category/", version = "0.9.0" }
 
 [features]
 default = []

--- a/unic/ucd/segment/Cargo.toml
+++ b/unic/ucd/segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-segment"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,9 +13,9 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-char-property = { path = "../../char/property/", version = "0.8.0" }
-unic-char-range = { path = "../../char/range", version = "0.8.0" }
-unic-ucd-version = { path = "../version/", version = "0.8.0" }
+unic-char-property = { path = "../../char/property/", version = "0.9.0" }
+unic-char-range = { path = "../../char/range", version = "0.9.0" }
+unic-ucd-version = { path = "../version/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/ucd/src/lib.rs
+++ b/unic/ucd/src/lib.rs
@@ -79,10 +79,7 @@ pub use crate::name::Name;
 
 pub use crate::normal::CanonicalCombiningClass;
 
-pub use crate::name_aliases::{
-    name_aliases_of,
-    NameAliasType,
-};
+pub use crate::name_aliases::{name_aliases_of, NameAliasType};
 
 pub use crate::segment::{GraphemeClusterBreak, SentenceBreak, WordBreak};
 

--- a/unic/ucd/version/Cargo.toml
+++ b/unic/ucd/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unic-ucd-version"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["The UNIC Project Developers"]
 repository = "https://github.com/open-i18n/rust-unic/"
@@ -13,7 +13,7 @@ categories = ["internationalization", "text-processing", "parsing", "rendering"]
 exclude = []
 
 [dependencies]
-unic-common = { path = "../../common/", version = "0.8.0" }
+unic-common = { path = "../../common/", version = "0.9.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
### Add

- `unic-ucd-name_aliases`: Unicode Name Alias character properties.

### Changed

- `unic-cli`: Fallback to  Name Alias for characters without Name value.

### Fixed

- `ucd-ident`: Use correct data table for `PatternWhitespace` property.
  [[GH-254](https://github.com/open-i18n/rust-unic/issues/254)]

### Misc

- Use external git submodules for source data.

- Migrate to Rust 2018 Edition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-i18n/rust-unic/258)
<!-- Reviewable:end -->
