### PR TITLE
Update to Rust/Cargo 1.45+

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ environment:
     CARGO_HTTP_CHECK_REVOKE: false
 
 test_script:
-  - cargo build --verbose --all
-  - cargo doc   --verbose --all --no-deps
+  - cargo build --verbose --workspace
+  - cargo doc   --verbose --workspace --no-deps
 
-  - cargo test  --verbose --all
+  - cargo test  --verbose --workspace

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,4 +27,3 @@ test_script:
   - cargo doc   --verbose --all --no-deps
 
   - cargo test  --verbose --all
-  - cargo test  --verbose --all --features serde

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ env:
     - RUST_BACKTRACE=full
 
 script:
-  - cargo build --verbose --all
-  - cargo doc   --verbose --all --no-deps
+  - cargo build --verbose --workspace
+  - cargo doc   --verbose --workspace --no-deps
 
-  - cargo test  --verbose --all
+  - cargo test  --verbose --workspace
 
   #  unic-ucd-normal is used in unic-ucd with non-default feature
   - cargo test  --verbose --manifest-path unic/ucd/normal/Cargo.toml
@@ -37,7 +37,7 @@ script:
   # == Nightly-only ==
 
   - test "$TRAVIS_RUST_VERSION" != "nightly" ||
-    cargo test  --verbose --all --all-features
+    cargo test  --verbose --workspace --all-features
 
 # TODO: - rustdoc --test README.md -L target/debug -L target/debug/deps
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ script:
   - cargo doc   --verbose --all --no-deps
 
   - cargo test  --verbose --all
-  - cargo test  --verbose --all --features serde
 
   #  unic-ucd-normal is used in unic-ucd with non-default feature
   - cargo test  --verbose --manifest-path unic/ucd/normal/Cargo.toml
@@ -39,10 +38,6 @@ script:
 
   - test "$TRAVIS_RUST_VERSION" != "nightly" ||
     cargo test  --verbose --all --all-features
-
-  # This takes too long, let's disable for now.
-  - test "$TRAVIS_RUST_VERSION" != "nightly" ||
-    cargo build --benches --verbose --all --features 'bench_it'
 
 # TODO: - rustdoc --test README.md -L target/debug -L target/debug/deps
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.31.0  # = MIN_RUST_VERSION
+  - 1.45.0  # = MIN_RUST_VERSION
 
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Travis](https://img.shields.io/travis/open-i18n/rust-unic/master.svg?label=Linux%20build)](https://travis-ci.org/open-i18n/rust-unic/)
 [![AppVeyor](https://img.shields.io/appveyor/ci/open-i18n/rust-unic/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/open-i18n/rust-unic)
-[![Rust-1.31.0+](https://img.shields.io/badge/rustc-1.31+-red.svg#MIN_RUST_VERSION)](https://www.rust-lang.org/)
+[![Rust-1.45+](https://img.shields.io/badge/rustc-1.45+-red.svg#MIN_RUST_VERSION)](https://www.rust-lang.org/)
 [![Unicode-10.0.0](https://img.shields.io/badge/unicode-10.0.0-red.svg)](https://www.unicode.org/versions/Unicode10.0.0/)
 [![Release](https://img.shields.io/github/release/open-i18n/rust-unic.svg)](https://github.com/open-i18n/rust-unic/)
 [![Crates.io](https://img.shields.io/crates/v/unic.svg)](https://crates.io/crates/unic/)

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -26,5 +26,3 @@ quickcheck = "0.6"
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/apps/cli/src/bin/unic-versions.rs
+++ b/apps/cli/src/bin/unic-versions.rs
@@ -12,8 +12,6 @@
 
 //! Command-line tool to list versions of UNIC components.
 
-use unic;
-
 macro_rules! print_component_desc {
     ( $component:tt ) => {
         println!("Component: {}", unic::$component::PKG_DESCRIPTION);

--- a/etc/cargo-clippy-all.sh
+++ b/etc/cargo-clippy-all.sh
@@ -10,8 +10,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-# Since `cargo publish --all` does not exist yet, we use this dumb alternative
-# solution for now.
+# Since `cargo clippy --workspace` does not exist yet, we use this dumb
+# alternative solution for now.
 #
 # Main downside of this approch is that there are separate `target/`
 # directories used for each component, increasing the test and publish process

--- a/etc/cargo-package-all.sh
+++ b/etc/cargo-package-all.sh
@@ -10,8 +10,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-# Since `cargo package --all` does not exist yet, we use this dumb alternative
-# solution for now.
+# Since `cargo package --workspace` does not exist yet, we use this dumb
+# alternative solution for now.
 #
 # Main downside of this approch is that there are separate `target/`
 # directories used for each component, increasing the test and publish process

--- a/etc/cargo-publish-all.sh
+++ b/etc/cargo-publish-all.sh
@@ -10,8 +10,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-# Since `cargo publish --all` does not exist yet, we use this dumb alternative
-# solution for now.
+# Since `cargo publish --workspaces` does not exist yet, we use this dumb
+# alternative solution for now.
 #
 # Main downside of this approch is that there are separate `target/`
 # directories used for each component, increasing the test and publish process

--- a/etc/cargo-test-all.sh
+++ b/etc/cargo-test-all.sh
@@ -10,8 +10,9 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-# Since `cargo publish --all` does not exist yet, we use this dumb alternative
-# solution for now.
+# Since `cargo publish --workspace` does not exist yet, we use this dumb
+# alternative solution for now to test all components in their isolated form,
+# before publishing them.
 #
 # Main downside of this approch is that there are separate `target/`
 # directories used for each component, increasing the test and publish process

--- a/gen/src/source/ucd/jamo.rs
+++ b/gen/src/source/ucd/jamo.rs
@@ -18,7 +18,7 @@ use crate::source::utils::read;
 
 lazy_static! {
     pub static ref JAMO_DATA: JamoData =
-        { read("external/unicode/ucd/data/Jamo.txt").parse().unwrap() };
+        read("external/unicode/ucd/data/Jamo.txt").parse().unwrap();
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/unic/Cargo.toml
+++ b/unic/Cargo.toml
@@ -36,5 +36,3 @@ unic-char-range = { path = "char/range/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/bidi/Cargo.toml
+++ b/unic/bidi/Cargo.toml
@@ -34,5 +34,3 @@ unic-ucd-version = { path = "../ucd/version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/bidi/benches/bidi_basic_benches.rs
+++ b/unic/bidi/benches/bidi_basic_benches.rs
@@ -20,10 +20,7 @@ use unic_bidi::BidiInfo;
 
 const LTR_TEXTS: &[&str] = &["abc\ndef\nghi", "abc 123\ndef 456\nghi 789"];
 
-const BIDI_TEXTS: &[&str] = &[
-    "ابجد\nهوز\nحتی",
-    "ابجد ۱۲۳\nهوز ۴۵۶\nحتی ۷۸۹\nabc\ndef",
-];
+const BIDI_TEXTS: &[&str] = &["ابجد\nهوز\nحتی", "ابجد ۱۲۳\nهوز ۴۵۶\nحتی ۷۸۹\nabc\ndef"];
 
 fn bench_bidi_info_new(b: &mut Bencher, texts: &[&str]) {
     for text in texts {

--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -617,22 +617,22 @@ mod tests {
 
     #[test]
     fn test_reorder_line() {
-        /// Bidi_Class: L L L B L L L B L L L
+        // Bidi_Class: L L L B L L L B L L L
         assert_eq!(
             reorder_paras("abc\ndef\nghi"),
             vec!["abc\n", "def\n", "ghi"]
         );
 
-        /// Bidi_Class: L L EN B L L EN B L L EN
+        // Bidi_Class: L L EN B L L EN B L L EN
         assert_eq!(
             reorder_paras("ab1\nde2\ngh3"),
             vec!["ab1\n", "de2\n", "gh3"]
         );
 
-        /// Bidi_Class: L L L B AL AL AL
+        // Bidi_Class: L L L B AL AL AL
         assert_eq!(reorder_paras("abc\nابج"), vec!["abc\n", "جبا"]);
 
-        /// Bidi_Class: AL AL AL B L L L
+        // Bidi_Class: AL AL AL B L L L
         assert_eq!(reorder_paras("ابج\nabc"), vec!["\nجبا", "abc"]);
 
         assert_eq!(reorder_paras("1.-2"), vec!["1.-2"]);

--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -238,7 +238,7 @@ impl<'text> BidiInfo<'text> {
     /// Re-order a line based on resolved levels and return only the embedding levels, one `Level`
     /// per *byte*.
     pub fn reordered_levels(&self, para: &ParagraphInfo, line: Range<usize>) -> Vec<Level> {
-        let (levels, _) = self.visual_runs(para, line.clone());
+        let (levels, _) = self.visual_runs(para, line);
         levels
     }
 
@@ -259,7 +259,7 @@ impl<'text> BidiInfo<'text> {
 
         // If all isolating run sequences are LTR, no reordering is needed
         if runs.iter().all(|run| levels[run.start].is_ltr()) {
-            return self.text[line.clone()].into();
+            return self.text[line].into();
         }
 
         let mut result = String::with_capacity(line.len());
@@ -278,7 +278,7 @@ impl<'text> BidiInfo<'text> {
     /// `line` is a range of bytes indices within `levels`.
     ///
     /// <https://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels>
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_range_loop))]
     pub fn visual_runs(
         &self,
         para: &ParagraphInfo,

--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -278,7 +278,7 @@ impl<'text> BidiInfo<'text> {
     /// `line` is a range of bytes indices within `levels`.
     ///
     /// <https://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels>
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_range_loop))]
+    #[allow(clippy::needless_range_loop)]
     pub fn visual_runs(
         &self,
         para: &ParagraphInfo,

--- a/unic/bidi/src/bidi_info.rs
+++ b/unic/bidi/src/bidi_info.rs
@@ -667,10 +667,7 @@ mod tests {
         assert_eq!(reorder_paras("A אבג?"), vec!["A גבא?"]);
 
         // Testing neutral characters with Implicit RTL Marker
-        assert_eq!(
-            reorder_paras("A אבג?\u{200F}"),
-            vec!["A \u{200F}?גבא"]
-        );
+        assert_eq!(reorder_paras("A אבג?\u{200F}"), vec!["A \u{200F}?גבא"]);
         assert_eq!(reorder_paras("אבג abc"), vec!["abc גבא"]);
         assert_eq!(
             reorder_paras("abc\u{2067}.-\u{2069}ghi"),
@@ -686,10 +683,7 @@ mod tests {
         assert_eq!(reorder_paras("א(ב)ג."), vec![".ג)ב(א"]);
 
         // With mirrorable characters on level boundry
-        assert_eq!(
-            reorder_paras("אב(גד[&ef].)gh"),
-            vec!["ef].)gh&[דג(בא"]
-        );
+        assert_eq!(reorder_paras("אב(גד[&ef].)gh"), vec!["ef].)gh&[דג(בא"]);
     }
 
     fn reordered_levels_for_paras(text: &str) -> Vec<Vec<Level>> {

--- a/unic/bidi/src/explicit.rs
+++ b/unic/bidi/src/explicit.rs
@@ -61,10 +61,10 @@ pub fn compute(
                 } else {
                     last_level.new_explicit_next_ltr()
                 };
-                // Until `let_chains` feature is stabilized.
-                #[allow(clippy::unnecessary_unwrap)]
                 if new_level.is_ok() && overflow_isolate_count == 0 && overflow_embedding_count == 0
                 {
+                    // Until `let_chains` feature is stabilized.
+                    #[allow(clippy::unnecessary_unwrap)]
                     let new_level = new_level.unwrap();
                     stack.push(
                         new_level,

--- a/unic/bidi/src/explicit.rs
+++ b/unic/bidi/src/explicit.rs
@@ -62,7 +62,7 @@ pub fn compute(
                     last_level.new_explicit_next_ltr()
                 };
                 // Until `let_chains` feature is stabilized.
-                #[cfg_attr(feature = "cargo-clippy", allow(clippy::unnecessary_unwrap))]
+                #[allow(clippy::unnecessary_unwrap)]
                 if new_level.is_ok() && overflow_isolate_count == 0 && overflow_embedding_count == 0
                 {
                     let new_level = new_level.unwrap();

--- a/unic/bidi/src/explicit.rs
+++ b/unic/bidi/src/explicit.rs
@@ -61,6 +61,8 @@ pub fn compute(
                 } else {
                     last_level.new_explicit_next_ltr()
                 };
+                // Until `let_chains` feature is stabilized.
+                #[cfg_attr(feature = "cargo-clippy", allow(clippy::unnecessary_unwrap))]
                 if new_level.is_ok() && overflow_isolate_count == 0 && overflow_embedding_count == 0
                 {
                     let new_level = new_level.unwrap();

--- a/unic/bidi/src/prepare.rs
+++ b/unic/bidi/src/prepare.rs
@@ -57,6 +57,7 @@ pub fn isolating_run_sequences(
     let mut stack = vec![Vec::new()];
 
     for run in runs {
+        #[allow(clippy::len_zero)]
         assert!(run.len() > 0);
         assert!(!stack.is_empty());
 

--- a/unic/bidi/src/prepare.rs
+++ b/unic/bidi/src/prepare.rs
@@ -187,7 +187,7 @@ mod tests {
     }
 
     // From <https://www.unicode.org/reports/tr9/#BD13>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn test_isolating_run_sequences() {
 
@@ -232,7 +232,7 @@ mod tests {
     }
 
     // From <https://www.unicode.org/reports/tr9/#X10>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn test_isolating_run_sequences_sos_and_eos() {
 

--- a/unic/char/Cargo.toml
+++ b/unic/char/Cargo.toml
@@ -26,5 +26,3 @@ unic-char-range = { path = "range/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/char/basics/Cargo.toml
+++ b/unic/char/basics/Cargo.toml
@@ -20,5 +20,3 @@ unic-char-range = { path = "../range/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/char/property/Cargo.toml
+++ b/unic/char/property/Cargo.toml
@@ -19,5 +19,3 @@ unic-char-range = { path = "../range/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/char/property/tests/bool_property_macro.rs
+++ b/unic/char/property/tests/bool_property_macro.rs
@@ -37,7 +37,7 @@ fn test_basics() {
     assert_eq!(is_my_prop('\u{0065}'), true);
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_bool))]
+#[allow(clippy::needless_bool)]
 #[test]
 fn test_into_bool() {
     assert!(if MyProp::of('\u{0065}').into() {

--- a/unic/char/range/Cargo.toml
+++ b/unic/char/range/Cargo.toml
@@ -29,5 +29,3 @@ trusted-len = []
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/common/Cargo.toml
+++ b/unic/common/Cargo.toml
@@ -20,5 +20,3 @@ unstable = []  # Rust nightly features
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/common/src/lib.rs
+++ b/unic/common/src/lib.rs
@@ -16,7 +16,6 @@
     unconditional_recursion
 )]
 #![forbid(unsafe_code)]
-#![cfg_attr(feature = "unstable", feature(unicode_version))]
 
 //! # UNIC — Common Utilities
 //!

--- a/unic/common/src/version.rs
+++ b/unic/common/src/version.rs
@@ -12,9 +12,6 @@
 
 use core::fmt;
 
-#[cfg(feature = "unstable")]
-use core::char;
-
 /// Represents a *Unicode Version* type.
 ///
 /// UNIC's *Unicode Version* type is used for Unicode datasets and specifications, including The
@@ -45,25 +42,25 @@ impl fmt::Display for UnicodeVersion {
     }
 }
 
-#[cfg(feature = "unstable")]
 /// Convert from Rust's internal Unicode Version.
-impl From<char::UnicodeVersion> for UnicodeVersion {
-    fn from(value: char::UnicodeVersion) -> UnicodeVersion {
+///
+/// `std::char::UNICODE_VERSION` is a tuple of the format `(major, minor, macro)`.
+impl From<(u8, u8, u8)> for UnicodeVersion {
+    fn from(value: (u8, u8, u8)) -> UnicodeVersion {
         UnicodeVersion {
-            major: value.major as u16,
-            minor: value.minor as u16,
-            micro: value.micro as u16,
+            major: value.0 as u16,
+            minor: value.1 as u16,
+            micro: value.2 as u16,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "unstable")]
+    use core::char;
+
     #[test]
     fn test_against_rust_internal() {
-        use core::char;
-
         use super::UnicodeVersion;
 
         let core_unicode_version: UnicodeVersion = char::UNICODE_VERSION.into();

--- a/unic/common/src/version.rs
+++ b/unic/common/src/version.rs
@@ -18,22 +18,19 @@ use core::fmt;
 /// Unicode Standard (TUS), Unicode Character Database (UCD), Common Local Data Repository (CLDR),
 /// IDNA, Emoji, etc.
 ///
-/// TODO: *Unicode Version* is guaranteed to have three integer fields between 0 and 255. We are
-/// going to switch over to `u8` after Unicode 11.0.0 release.
-///
 /// Refs:
 /// - <https://www.unicode.org/versions/>
 /// - <https://www.unicode.org/L2/L2017/17222.htm#152-C3>
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Default)]
 pub struct UnicodeVersion {
     /// Major version.
-    pub major: u16,
+    pub major: u8,
 
     /// Minor version.
-    pub minor: u16,
+    pub minor: u8,
 
     /// Micro (or Update) version.
-    pub micro: u16,
+    pub micro: u8,
 }
 
 impl fmt::Display for UnicodeVersion {
@@ -46,11 +43,11 @@ impl fmt::Display for UnicodeVersion {
 ///
 /// `std::char::UNICODE_VERSION` is a tuple of the format `(major, minor, macro)`.
 impl From<(u8, u8, u8)> for UnicodeVersion {
-    fn from(value: (u8, u8, u8)) -> UnicodeVersion {
+    fn from((major, minor, micro): (u8, u8, u8)) -> UnicodeVersion {
         UnicodeVersion {
-            major: value.0 as u16,
-            minor: value.1 as u16,
-            micro: value.2 as u16,
+            major,
+            minor,
+            micro,
         }
     }
 }

--- a/unic/emoji/Cargo.toml
+++ b/unic/emoji/Cargo.toml
@@ -19,5 +19,3 @@ unic-emoji-char = { path = "char/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/emoji/char/Cargo.toml
+++ b/unic/emoji/char/Cargo.toml
@@ -21,5 +21,3 @@ unic-ucd-version = { path = "../../ucd/version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/examples/bidi_example.rs
+++ b/unic/examples/bidi_example.rs
@@ -13,7 +13,7 @@
 
 use unic::bidi::BidiInfo;
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn main() {
     let text = concat![
         "א",

--- a/unic/examples/ucd_bidi_traits_example.rs
+++ b/unic/examples/ucd_bidi_traits_example.rs
@@ -13,7 +13,7 @@
 
 use unic::ucd::bidi::{BidiClass, BidiClassCategory, CharBidiClass, StrBidiClass};
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn main() {
     let text = concat![
         "א",

--- a/unic/idna/Cargo.toml
+++ b/unic/idna/Cargo.toml
@@ -26,5 +26,3 @@ unic-ucd-version = { path = "../ucd/version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/idna/mapping/Cargo.toml
+++ b/unic/idna/mapping/Cargo.toml
@@ -21,5 +21,3 @@ unic-ucd-version = { path = "../../ucd/version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/idna/mapping/src/mapping.rs
+++ b/unic/idna/mapping/src/mapping.rs
@@ -39,7 +39,7 @@ mod data {
     use super::Mapping::*;
     use unic_char_property::tables::CharDataTable;
 
-    #[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
+    #[allow(clippy::unreadable_literal)]
     pub const MAPPING: CharDataTable<super::Mapping> = include!("../tables/idna_mapping.rsv");
 }
 

--- a/unic/idna/punycode/Cargo.toml
+++ b/unic/idna/punycode/Cargo.toml
@@ -20,5 +20,3 @@ rustc-serialize = "0.3"
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/idna/punycode/src/lib.rs
+++ b/unic/idna/punycode/src/lib.rs
@@ -69,7 +69,7 @@ pub fn decode_to_string(input: &str) -> Option<String> {
 /// Return None on malformed input or overflow.
 /// Overflow can only happen on inputs that take more than
 /// 63 encoded bytes, the DNS limit on domain name labels.
-#[cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
+#[allow(clippy::cast_lossless)]
 pub fn decode(input: &str) -> Option<Vec<char>> {
     // Handle "basic" (ASCII) code points.
     // They are encoded as-is before the last delimiter, if any.

--- a/unic/idna/src/process.rs
+++ b/unic/idna/src/process.rs
@@ -17,7 +17,7 @@ use crate::mapping::Mapping;
 use crate::punycode;
 
 /// Prefix used in Punycode encoding.
-pub static PUNYCODE_PREFIX: &'static str = "xn--";
+pub static PUNYCODE_PREFIX: &str = "xn--";
 
 fn map_char(codepoint: char, flags: Flags, output: &mut String, errors: &mut Vec<Error>) {
     match Mapping::of(codepoint) {

--- a/unic/idna/src/process.rs
+++ b/unic/idna/src/process.rs
@@ -465,10 +465,7 @@ mod tests {
         assert_eq!(_to_ascii("אבּג"), Ok("xn--kdb3bdf".to_owned()));
         assert_eq!(_to_ascii("ابج"), Ok("xn--mgbcm".to_owned()));
         assert_eq!(_to_ascii("abc.ابج"), Ok("abc.xn--mgbcm".to_owned()));
-        assert_eq!(
-            _to_ascii("אבּג.ابج"),
-            Ok("xn--kdb3bdf.xn--mgbcm".to_owned())
-        );
+        assert_eq!(_to_ascii("אבּג.ابج"), Ok("xn--kdb3bdf.xn--mgbcm".to_owned()));
 
         // Bidi domain names cannot start with digits
         assert!(_to_ascii("0a.\u{05D0}").is_err());

--- a/unic/idna/src/process.rs
+++ b/unic/idna/src/process.rs
@@ -159,7 +159,7 @@ fn passes_bidi(label: &str, is_bidi_domain: bool) -> bool {
 }
 
 // https://www.unicode.org/reports/tr46/#Validity_Criteria
-#[cfg_attr(feature = "cargo-clippy", allow(if_same_then_else))]
+#[allow(clippy::if_same_then_else)]
 fn validate(label: &str, is_bidi_domain: bool, flags: Flags, errors: &mut Vec<Error>) {
     let first_char = label.chars().next();
 
@@ -296,7 +296,7 @@ pub struct Flags {
 }
 
 /// Error types recorded during UTS #46 processing.
-#[cfg_attr(feature = "cargo-clippy", allow(enum_variant_names))]
+#[allow(clippy::enum_variant_names)]
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 enum Error {
     PunycodeError,

--- a/unic/normal/Cargo.toml
+++ b/unic/normal/Cargo.toml
@@ -23,5 +23,3 @@ unic-ucd-version = { path = "../ucd/version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/segment/Cargo.toml
+++ b/unic/segment/Cargo.toml
@@ -24,5 +24,3 @@ unic-ucd-common = { path = "../ucd/common/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/segment/src/grapheme.rs
+++ b/unic/segment/src/grapheme.rs
@@ -273,7 +273,7 @@ enum PairResult {
 fn check_pair(before: GCB, after: GCB) -> PairResult {
     use self::PairResult::*;
 
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[allow(clippy::match_same_arms)]
     match (before, after) {
         // Do not break between a CR and LF. Otherwise, break before and after controls.
         (GCB::CR, GCB::LF) => NotBreak, // GB3
@@ -533,7 +533,7 @@ impl GraphemeCursor {
     // TODO(clippy): Fix clippy warning or leave it as allowed if really needed.
     // `warning: methods called `is_*` usually take self by reference or no self; consider choosing
     // a less ambiguous name`
-    #[cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]
+    #[allow(clippy::wrong_self_convention)]
     /// Determine whether the current cursor location is a grapheme cluster boundary.
     /// Only a part of the string need be supplied. If `chunk_start` is nonzero or
     /// the length of `chunk` is not equal to `len` on creation, then this method

--- a/unic/segment/src/word.rs
+++ b/unic/segment/src/word.rs
@@ -168,7 +168,7 @@ impl<'a> Iterator for WordBounds<'a> {
     }
 
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[allow(clippy::match_same_arms)]
     fn next(&mut self) -> Option<&'a str> {
         use self::FormatExtendType::*;
         use self::WordBoundsState::*;
@@ -401,7 +401,7 @@ impl<'a> Iterator for WordBounds<'a> {
 
 impl<'a> DoubleEndedIterator for WordBounds<'a> {
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
+    #[allow(clippy::cyclomatic_complexity)]
     fn next_back(&mut self) -> Option<&'a str> {
         use self::FormatExtendType::*;
         use self::WordBoundsState::*;

--- a/unic/segment/src/word.rs
+++ b/unic/segment/src/word.rs
@@ -401,7 +401,7 @@ impl<'a> Iterator for WordBounds<'a> {
 
 impl<'a> DoubleEndedIterator for WordBounds<'a> {
     #[inline]
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     fn next_back(&mut self) -> Option<&'a str> {
         use self::FormatExtendType::*;
         use self::WordBoundsState::*;

--- a/unic/src/lib.rs
+++ b/unic/src/lib.rs
@@ -48,7 +48,7 @@
 //! use unic::ucd::normal::compose;
 //! use unic::ucd::{is_cased, Age, BidiClass, CharAge, CharBidiClass, StrBidiClass, UnicodeVersion};
 //!
-//! #[cfg_attr(rustfmt, rustfmt_skip)]
+//! #[rustfmt::skip]
 //! #[test]
 //! fn test_sample() {
 //!

--- a/unic/tests/basics_test.rs
+++ b/unic/tests/basics_test.rs
@@ -18,7 +18,7 @@ use unic::ucd::common::is_alphanumeric;
 use unic::ucd::normal::compose;
 use unic::ucd::{is_cased, Age, BidiClass, CharAge, CharBidiClass, StrBidiClass, UnicodeVersion};
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 #[test]
 fn test_sample() {
 

--- a/unic/ucd/Cargo.toml
+++ b/unic/ucd/Cargo.toml
@@ -38,5 +38,3 @@ unic-char-range = { path = "../char/range/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/age/Cargo.toml
+++ b/unic/ucd/age/Cargo.toml
@@ -21,5 +21,3 @@ unic-ucd-version = { path = "../version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/bidi/Cargo.toml
+++ b/unic/ucd/bidi/Cargo.toml
@@ -21,5 +21,3 @@ unic-ucd-version = { path = "../version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/block/Cargo.toml
+++ b/unic/ucd/block/Cargo.toml
@@ -21,5 +21,3 @@ unic-ucd-version = { path = "../version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/block/src/block.rs
+++ b/unic/ucd/block/src/block.rs
@@ -19,15 +19,13 @@ use unic_char_range::CharRange;
 /// All Assigned characters have a Block property value, but Reserved characters may or may not
 /// have a Block.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub struct Block {
     /// The Character range of the Block.
     pub range: CharRange,
 
     /// The unique name of the Block.
     pub name: &'static str,
-
-    // Private field to keep struct expandable.
-    _priv: (),
 }
 
 impl Block {
@@ -35,11 +33,7 @@ impl Block {
     pub fn of(ch: char) -> Option<Block> {
         match data::BLOCKS.find_with_range(ch) {
             None => None,
-            Some((range, name)) => Some(Block {
-                range,
-                name,
-                _priv: (),
-            }),
+            Some((range, name)) => Some(Block { range, name }),
         }
     }
 }
@@ -80,11 +74,7 @@ impl<'a> Iterator for BlockIter<'a> {
     fn next(&mut self) -> Option<Block> {
         match self.iter.next() {
             None => None,
-            Some((range, name)) => Some(Block {
-                range,
-                name,
-                _priv: (),
-            }),
+            Some((range, name)) => Some(Block { range, name }),
         }
     }
 }

--- a/unic/ucd/case/Cargo.toml
+++ b/unic/ucd/case/Cargo.toml
@@ -21,5 +21,3 @@ unic-ucd-version = { path = "../version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/category/Cargo.toml
+++ b/unic/ucd/category/Cargo.toml
@@ -22,5 +22,3 @@ unic-ucd-version = { path = "../version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/common/Cargo.toml
+++ b/unic/ucd/common/Cargo.toml
@@ -24,5 +24,3 @@ unic-ucd-category = { path = "../category/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/hangul/Cargo.toml
+++ b/unic/ucd/hangul/Cargo.toml
@@ -19,5 +19,3 @@ unic-ucd-version = { path = "../version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/hangul/src/hangul.rs
+++ b/unic/ucd/hangul/src/hangul.rs
@@ -23,8 +23,8 @@ pub const T_BASE: u32 = 0x11A7;
 pub const L_COUNT: u32 = 19;
 pub const V_COUNT: u32 = 21;
 pub const T_COUNT: u32 = 28;
-pub const N_COUNT: u32 = (V_COUNT * T_COUNT);
-pub const S_COUNT: u32 = (L_COUNT * N_COUNT);
+pub const N_COUNT: u32 = V_COUNT * T_COUNT;
+pub const S_COUNT: u32 = L_COUNT * N_COUNT;
 
 /// Whether the character is a (precomposed) Hangul Syllable
 pub fn is_syllable(ch: char) -> bool {

--- a/unic/ucd/ident/Cargo.toml
+++ b/unic/ucd/ident/Cargo.toml
@@ -33,5 +33,3 @@ matches = "0.1"
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/name/Cargo.toml
+++ b/unic/ucd/name/Cargo.toml
@@ -21,5 +21,3 @@ unic-char-property = { path = "../../char/property/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/name/src/name.rs
+++ b/unic/ucd/name/src/name.rs
@@ -12,11 +12,11 @@ use core::cmp::Ordering;
 use core::fmt;
 use unic_ucd_hangul::decompose_syllable;
 
-pub static PREFIX_HANGUL_SYLLABLE: &'static str = "HANGUL SYLLABLE ";
-pub static PREFIX_CJK_UNIFIED_IDEOGRAPH: &'static str = "CJK UNIFIED IDEOGRAPH-";
-pub static PREFIX_TANGUT_IDEOGRAPH: &'static str = "TANGUT IDEOGRAPH-";
-pub static PREFIX_NUSHU_CHARACTER: &'static str = "NUSHU CHARACTER-";
-pub static PREFIX_CJK_COMPATIBILITY_IDEOGRAPH: &'static str = "CJK COMPATIBILITY IDEOGRAPH-";
+pub static PREFIX_HANGUL_SYLLABLE: &str = "HANGUL SYLLABLE ";
+pub static PREFIX_CJK_UNIFIED_IDEOGRAPH: &str = "CJK UNIFIED IDEOGRAPH-";
+pub static PREFIX_TANGUT_IDEOGRAPH: &str = "TANGUT IDEOGRAPH-";
+pub static PREFIX_NUSHU_CHARACTER: &str = "NUSHU CHARACTER-";
+pub static PREFIX_CJK_COMPATIBILITY_IDEOGRAPH: &str = "CJK COMPATIBILITY IDEOGRAPH-";
 
 const JAMO_BUFFER_SIZE: usize = 3;
 
@@ -49,7 +49,7 @@ pub enum Name {
     NR3(&'static [&'static str]),
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::len_without_is_empty))]
 impl Name {
     /// Find the character `Name` property value.
     pub fn of(ch: char) -> Option<Name> {
@@ -101,7 +101,7 @@ impl Name {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always))]
     #[inline(always)]
     fn number_of_hex_digits(ch: char) -> usize {
         (32 - u32::leading_zeros(ch as u32) as usize + 3) / 4

--- a/unic/ucd/name/src/name.rs
+++ b/unic/ucd/name/src/name.rs
@@ -49,7 +49,7 @@ pub enum Name {
     NR3(&'static [&'static str]),
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::len_without_is_empty))]
+#[allow(clippy::len_without_is_empty)]
 impl Name {
     /// Find the character `Name` property value.
     pub fn of(ch: char) -> Option<Name> {
@@ -101,7 +101,7 @@ impl Name {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always))]
+    #[allow(clippy::inline_always)]
     #[inline(always)]
     fn number_of_hex_digits(ch: char) -> usize {
         (32 - u32::leading_zeros(ch as u32) as usize + 3) / 4

--- a/unic/ucd/name_aliases/Cargo.toml
+++ b/unic/ucd/name_aliases/Cargo.toml
@@ -20,5 +20,3 @@ unic-char-property = { path = "../../char/property/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/normal/Cargo.toml
+++ b/unic/ucd/normal/Cargo.toml
@@ -29,5 +29,3 @@ default = []
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/normal/src/canonical_combining_class.rs
+++ b/unic/ucd/normal/src/canonical_combining_class.rs
@@ -57,7 +57,7 @@ mod data {
         include!("../tables/canonical_combining_class_values.rsv");
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]  // We want the consts ordered by value.
+#[rustfmt::skip]  // We want the consts ordered by value.
 #[allow(non_upper_case_globals)]
 impl CanonicalCombiningClass {
     /// Find the character `Canonical_Combining_Class` property value.

--- a/unic/ucd/normal/src/composition.rs
+++ b/unic/ucd/normal/src/composition.rs
@@ -22,7 +22,7 @@ pub mod data {
     pub const CANONICAL_DECOMPOSITION_MAPPING: CharDataTable<&[char]> =
         include!("../tables/canonical_decomposition_mapping.rsv");
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     pub const COMPATIBILITY_DECOMPOSITION_MAPPING: CharDataTable<(DecompositionType, &[char])> =
         include!("../tables/compatibility_decomposition_mapping.rsv");
 }

--- a/unic/ucd/normal/src/gen_cat.rs
+++ b/unic/ucd/normal/src/gen_cat.rs
@@ -24,9 +24,7 @@ mod mark {
 
 #[cfg(feature = "unic-ucd-category")]
 mod mark {
-    use unic_ucd_category;
-
-    use self::unic_ucd_category::GeneralCategory;
+    use unic_ucd_category::GeneralCategory;
 
     /// Return whether the given character is a combining mark (`General_Category=Mark`)
     pub fn is_combining_mark(c: char) -> bool {

--- a/unic/ucd/segment/Cargo.toml
+++ b/unic/ucd/segment/Cargo.toml
@@ -21,5 +21,3 @@ unic-ucd-version = { path = "../version/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }

--- a/unic/ucd/tests/bidi_class_consistency_tests.rs
+++ b/unic/ucd/tests/bidi_class_consistency_tests.rs
@@ -23,7 +23,7 @@ use unic_ucd::bidi::BidiClass as BC;
 use unic_ucd::category::GeneralCategory as GC;
 
 #[test]
-#[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+#[allow(match_same_arms)]
 fn test_from_bidi_class() {
     for cp in chars!(..) {
         match BC::of(cp) {

--- a/unic/ucd/version/Cargo.toml
+++ b/unic/ucd/version/Cargo.toml
@@ -19,5 +19,3 @@ unic-common = { path = "../../common/", version = "0.9.0" }
 maintenance = { status = "actively-developed" }
 is-it-maintained-issue-resolution = { repository = "open-i18n/rust-unic" }
 is-it-maintained-open-issues = { repository = "open-i18n/rust-unic" }
-appveyor = { repository = "open-i18n/rust-unic", branch = "master", service = "github" }
-travis-ci = { repository = "open-i18n/rust-unic", branch = "master" }


### PR DESCRIPTION
- Fix some compiler warnings.
- Use `std::char::UNICODE_VERSION`, stabilized in Rust 1.4.50.
- Clippy: update the rule control syntax, and fix a few warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-i18n/rust-unic/275)
<!-- Reviewable:end -->
