### PR TITLE
Update quickcheck dev-dependency to v1

### DIFF
--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -20,7 +20,7 @@ regex = "0.2"
 
 [dev-dependencies]
 assert_cli = "0.5"
-quickcheck = "0.6"
+quickcheck = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/unic/segment/Cargo.toml
+++ b/unic/segment/Cargo.toml
@@ -17,7 +17,7 @@ exclude = []
 unic-ucd-segment = { path = "../ucd/segment/", version = "0.9.0" }
 
 [dev-dependencies]
-quickcheck = "0.6"
+quickcheck = "1.0"
 unic-ucd-common = { path = "../ucd/common/", version = "0.9.0" }
 
 [badges]


### PR DESCRIPTION
This allows using the latest release of `quickcheck`, and does not produce any regressions in the tests.

https://crates.io/crates/quickcheck

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-i18n/rust-unic/289)
<!-- Reviewable:end -->
